### PR TITLE
Add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+out/
+data/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:current-alpine3.15 as build
+
+WORKDIR /build
+ADD package*.json ./
+RUN npm ci --ignore-scripts && npm cache clean --force
+ADD . .
+RUN npm run build && npm prune --omit=dev
+
+FROM node:current-alpine3.15
+
+WORKDIR /app
+COPY --from=build /build/package.json ./
+COPY --from=build /build/node_modules ./node_modules
+COPY --from=build /build/bin ./bin
+COPY --from=build /build/out ./out
+RUN chmod +x ./bin/magireco-cn-local-server
+RUN ln -s /app/bin/magireco-cn-local-server /usr/local/bin/magireco-cn-local-server
+
+WORKDIR /data
+VOLUME /data
+EXPOSE 10000 10001 10002 10003
+
+ENTRYPOINT [ "magireco-cn-local-server" ]

--- a/bin/magireco-cn-local-server
+++ b/bin/magireco-cn-local-server
@@ -7,4 +7,8 @@ if (process.env.npm_package_version == null) {
     } catch (e) {}
 }
 
+for (const signal of ["SIGINT", "SIGTERM", "SIGQUIT"]) {
+    process.on(signal, () => process.exit());
+}
+
 require("../out/proxy_main.js");


### PR DESCRIPTION
添加docker镜像构建支持，方便部署在远程服务器上使用。

构建命令举例：
```
docker build -t segfault-bilibili/magireco-cn-local-server:latest .
```

运行命令举例：
```
docker run --rm --net host --name magireco -v $(pwd)/data:/data segfault-bilibili/magireco-cn-local-server
```

Dockerfile expose了10000-10003端口，并设置/data目录作为挂载点，用于存放服务器状态文件和从外部下载的数据。